### PR TITLE
Add "nomkl" as a dependency to avoid installing mkl versions of lapack (and other packages)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,14 @@ requirements:
     - python
     - pip
     - setuptools
+    - nomkl
     - numpy
     - fftw >=3.3.8
     - liblapack >=3.8
     - openblas
   run:
     - python
+    - nomkl
     - numpy
     - fftw >=3.3.8
     - liblapack >=3.8


### PR DESCRIPTION
## Solution 1: Adding `nomkl` as a dependency

Here I added the package "nomkl" as a dependency in order to avoid using the mkl versions of these packages:
```
libblas:         3.9.0-7_mkl
libcblas:        3.9.0-7_mkl 
liblapack:       3.9.0-7_mkl
```
Adding `nomkl` installs these packages instead
```
libblas:         3.9.0-3_h3cd88c1_netlib  conda-forge
libcblas:        3.9.0-3_h3cd88c1_netlib  conda-forge
liblapack:       3.9.0-3_h3cd88c1_netlib  conda-forge
```

As far as I can tell, nomkl is a dummy package that just ensures mkl isn't installed. I have to admit, though, that I am not 100% sure if this is the best solution, or if this will have unintended consequences. For example, what if someone wanted to install mkl for another project? 

Any comments or advice would be appreciated, as I find this very confusing! (see also "solution 2")

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
