### PR TITLE
Use "liblapack >=3.8=*openblas" to avoid installing mkl

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,13 +24,13 @@ requirements:
     - setuptools
     - numpy
     - fftw >=3.3.8
-    - liblapack >=3.8
+    - liblapack >=3.8=*openblas
     - openblas
   run:
     - python
     - numpy
     - fftw >=3.3.8
-    - liblapack >=3.8
+    - liblapack >=3.8=*openblas
     - openblas
     - scipy >=0.14.0
     - matplotlib-base >=3.3


### PR DESCRIPTION
## Solution 2: use "liblapack >=3.8=*openblas"

Here, instead of installing the dummy project "nomkl", I instead explicitly specify the build type of the liblapack library using 
```
liblapack >=3.8=*openblas
```
This installs the following:
```
libblas:          3.9.0-7_openblas               conda-forge
libcblas:         3.9.0-7_openblas               conda-forge
liblapack:        3.9.0-7_openblas               conda-forge
```
This is probably the better solution, especially since openblas is installed as a dependency. I don't fully understand the syntax here, so let me know if there is something wrong!


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
