### PR TITLE
Revert previous change that pinned setuptools to 62.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools <=62.0.0
+    - setuptools
     # Don't add constraints to the following 3 to use conda-forge global settings
     - numpy
     - fftw


### PR DESCRIPTION
As an attempt to get some of the recent PRs to build, it was necessary to pin setuptools to 62.0.0. In the most recent version (62.1.0) the locations of the build directories changed, causing compilation errors. Though using 62.0.0 helped, the PR still failed...

I have fixed the pyshtools `setup.py` file to deal with both the old 62.0.0 and 62.1.0 build directory locations. I will be starting a new release soon (today?), so it is no longer necessary to pin setuptools. We will see what happens then...

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
